### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/rezadzed/Tonk-Battlefild/security/code-scanning/2](https://github.com/rezadzed/Tonk-Battlefild/security/code-scanning/2)

To fix the problem, we need to set explicit permissions for the `build` job to restrict the scope of the `GITHUB_TOKEN` used during execution. The best way to do this is to add a `permissions` block to the `build` job, specifying only the privileges necessary. For the `build` job (which runs `checkout`, sets up node, installs dependencies, and runs tests), `contents: read` is sufficient—it allows the job to checkout code, but not make changes. No other permission is needed. This change should be made by inserting or updating the block below `runs-on: ubuntu-latest` within the `build` job without modifying other functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
